### PR TITLE
add img family, img project, shielded_vm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,10 @@ module "instance_template" {
     email  = google_service_account.bastion_host.email
     scopes = var.scopes
   }
-  enable_shielded_vm = true
-  startup_script     = var.startup_script
+  enable_shielded_vm   = var.shielded_vm
+  source_image_family  = var.image_family
+  source_image_project = var.image_project
+  startup_script       = var.startup_script
 
   metadata = {
     enable-oslogin = "TRUE"

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-variable "image" {
-  description = "GCE image on which to base the Bastion. This image is supported by Shielded VM"
-  default     = "gce-uefi-images/centos-7"
+variable "image_family" {
+  description = "Source image family for the Bastion."
+  default     = "centos-7"
+}
+
+variable "image_project" {
+  description = "Project where the source image for the Bastion comes from"
+  default     = "gce-uefi-images"
 }
 
 variable "labels" {


### PR DESCRIPTION
fixes #9 
- Pass image family, image project to instance template with centos as default
- Pass shielded_vm bool to instance template
