### PR TITLE
Remove deprecated quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ provision a project with the necessary APIs enabled.
 | image\_project | Project where the source image for the Bastion comes from | string | `"gce-uefi-images"` | no |
 | labels | Key-value map of labels to assign to the bastion host | map | `<map>` | no |
 | machine\_type | Instance type for the Bastion host | string | `"n1-standard-1"` | no |
-| members | List of IAM resources to allow access to the bastion host | list | `<list>` | no |
+| members | List of IAM resources to allow access to the bastion host | list(string) | `<list>` | no |
 | name | Name of the Bastion instance | string | `"bastion-vm"` | no |
 | network | Self link for the network on which the Bastion should live | string | n/a | yes |
 | project | The project ID to deploy to | string | n/a | yes |
+| random\_role\_id | Enables role random id generation. | bool | `"true"` | no |
 | region | The primary region where the bastion host will live | string | `"us-central1"` | no |
 | scopes | List of scopes to attach to the bastion host | list | `<list>` | no |
 | service\_account\_roles | List of IAM roles to assign to the service account. | list | `<list>` | no |
@@ -78,6 +79,7 @@ provision a project with the necessary APIs enabled.
 | shielded\_vm | Enable shielded VM on the bastion host (recommended) | string | `"true"` | no |
 | startup\_script | Render a startup script with a template. | string | `""` | no |
 | subnet | Self link for the subnet on which the Bastion should live. Can be private when using IAP | string | n/a | yes |
+| tags | Network tags, provided as a list | list(string) | `<list>` | no |
 | zone | The primary zone where the bastion host will live | string | `"us-central1-a"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "google_compute_firewall" "allow_from_iap_to_bastion" {
 }
 
 resource "google_iap_tunnel_instance_iam_binding" "enable_iap" {
-  provider = "google-beta"
+  provider = google-beta
   project  = var.project
   zone     = var.zone
   instance = google_compute_instance_from_template.bastion_vm.name

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "tags" {
 
 variable "labels" {
   description = "Key-value map of labels to assign to the bastion host"
-  type        = "map"
+  type        = map
   default     = {}
 }
 
@@ -43,7 +43,7 @@ variable "machine_type" {
 
 variable "members" {
   description = "List of IAM resources to allow access to the bastion host"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
Terraform 0.11 and earlier required type constraints & references to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform.

This PR removes the deprecated quotes to avoid warning messages:

```
Warning: Quoted references are deprecated

  on main.tf line 91, in resource "google_iap_tunnel_instance_iam_binding" "enable_iap":
  91:   provider = "google-beta"

Warning: Quoted type constraints are deprecated     

  on variables.tf line 46, in variable "members":
  46:   type        = "list"

Warning: Quoted type constraints are deprecated

  on variables.tf line 35, in variable "labels":
  35:   type        = "map"
```