### PR TITLE
Pull out IAP to its own module.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,3 +39,8 @@ suites:
       name: terraform
       command_timeout: 1800
       root_module_directory: test/fixtures/bastion_group
+  - name: iap_tunneling
+    driver:
+      name: terraform
+      command_timeout: 1800
+      root_module_directory: test/fixtures/iap_tunneling

--- a/examples/iap_tunneling/README.md
+++ b/examples/iap_tunneling/README.md
@@ -1,0 +1,48 @@
+# IAP Tunneling Example
+
+This example will create a testing VM and set up the firewall and IAM bindings to allow IAP connections to it for given members.
+
+## Deploy
+
+Create a `terraform.tfvars` file with required variables similar to:
+
+```
+members = ["user:me@example.com"]
+project = "my-project"
+instance = "instance-1"
+zone     = "us-central1-a"
+```
+
+Run the apply
+
+```
+terraform apply
+```
+
+## Usage
+
+You can ssh to the VM instance with something similar to the following:
+
+```
+gcloud auth login
+gcloud compute ssh instance-1 --zone us-central1-a --project my-project
+```
+
+You should now be logged in as a user that looks like `ext_me_example_com` with the prefix of `ext` indicating you have logged in with OS Login.
+You should also notice the following line in standard out that indicates you are tunnelling through IAP instead of the public internet:
+
+```
+External IP address was not found; defaulting to using IAP tunneling.
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| instance | Name of the example VM instance to create and allow SSH from IAP. | string | n/a | yes |
+| members | List of members in the standard GCP form: user:{email}, serviceAccount:{email}, group:{email} | list(string) | n/a | yes |
+| project | Project ID where to set up the instance and IAP tunneling | string | n/a | yes |
+| zone | Zone of the example VM instance to create and allow SSH from IAP. | string | n/a | yes |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iap_tunneling/README.md
+++ b/examples/iap_tunneling/README.md
@@ -11,6 +11,7 @@ members = ["user:me@example.com"]
 project = "my-project"
 instance = "instance-1"
 zone     = "us-central1-a"
+region   = "us-central1"
 ```
 
 Run the apply
@@ -43,6 +44,7 @@ External IP address was not found; defaulting to using IAP tunneling.
 | instance | Name of the example VM instance to create and allow SSH from IAP. | string | n/a | yes |
 | members | List of members in the standard GCP form: user:{email}, serviceAccount:{email}, group:{email} | list(string) | n/a | yes |
 | project | Project ID where to set up the instance and IAP tunneling | string | n/a | yes |
-| zone | Zone of the example VM instance to create and allow SSH from IAP. | string | n/a | yes |
+| region | Region to create the subnet and example VM. | string | `"us-west1"` | no |
+| zone | Zone of the example VM instance to create and allow SSH from IAP. | string | `"us-west1-a"` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iap_tunneling/main.tf
+++ b/examples/iap_tunneling/main.tf
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_service_account" "vm_sa" {
+  project      = var.project
+  account_id   = var.instance
+  display_name = "Service Account for VM"
+}
+
+# A testing VM to allow OS Login + IAP tunneling.
+module "instance_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "1.1.0"
+
+  project_id   = var.project
+  machine_type = "n1-standard-1"
+  network      = "default"
+  service_account = {
+    email  = google_service_account.vm_sa.email
+    scopes = ["cloud-platform"]
+  }
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+}
+
+resource "google_compute_instance_from_template" "vm" {
+  name    = var.instance
+  project = var.project
+  zone    = var.zone
+  network_interface {
+    network = "default"
+  }
+  source_instance_template = module.instance_template.self_link
+}
+
+# Additional OS login IAM bindings.
+# https://cloud.google.com/compute/docs/instances/managing-instance-access#granting_os_login_iam_roles
+resource "google_service_account_iam_binding" "sa_user" {
+  service_account_id = google_service_account.vm_sa.id
+  role               = "roles/iam.serviceAccountUser"
+  members            = var.members
+}
+
+resource "google_project_iam_member" "os_login_bindings" {
+  for_each = toset(var.members)
+  project  = var.project
+  role     = "roles/compute.osLogin"
+  member   = each.key
+}
+
+module "iap_tunneling" {
+  source           = "../../modules/iap-tunneling"
+  project          = var.project
+  network          = "default"
+  service_accounts = [google_service_account.vm_sa.email]
+  instances = [{
+    name = google_compute_instance_from_template.vm.name
+    zone = var.zone
+  }]
+  members = var.members
+}

--- a/examples/iap_tunneling/variables.tf
+++ b/examples/iap_tunneling/variables.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "members" {
+  description = "List of members in the standard GCP form: user:{email}, serviceAccount:{email}, group:{email}"
+  type        = list(string)
+}
+
+variable "project" {
+  description = "Project ID where to set up the instance and IAP tunneling"
+}
+
+variable "instance" {
+  description = "Name of the example VM instance to create and allow SSH from IAP."
+}
+
+variable "zone" {
+  description = "Zone of the example VM instance to create and allow SSH from IAP."
+}

--- a/examples/iap_tunneling/variables.tf
+++ b/examples/iap_tunneling/variables.tf
@@ -27,6 +27,12 @@ variable "instance" {
   description = "Name of the example VM instance to create and allow SSH from IAP."
 }
 
+variable "region" {
+  description = "Region to create the subnet and example VM."
+  default     = "us-west1"
+}
+
 variable "zone" {
   description = "Zone of the example VM instance to create and allow SSH from IAP."
+  default     = "us-west1-a"
 }

--- a/main.tf
+++ b/main.tf
@@ -79,10 +79,12 @@ module "iap_tunneling" {
   project                    = var.project
   fw_name_allow_ssh_from_iap = var.fw_name_allow_ssh_from_iap
   network                    = var.network
-  service_account            = google_service_account.bastion_host.email
-  zone                       = var.zone
-  name                       = var.create_instance_from_template ? google_compute_instance_from_template.bastion_vm[0].name : ""
-  members                    = var.members
+  service_accounts           = [google_service_account.bastion_host.email]
+  instances = var.create_instance_from_template ? [{
+    name = google_compute_instance_from_template.bastion_vm[0].name
+    zone = var.zone
+  }] : []
+  members = var.members
 }
 
 resource "google_service_account_iam_binding" "bastion_sa_user" {

--- a/main.tf
+++ b/main.tf
@@ -72,30 +72,17 @@ resource "google_compute_instance_from_template" "bastion_vm" {
   source_instance_template = module.instance_template.self_link
 }
 
-resource "google_compute_firewall" "allow_from_iap_to_bastion" {
-  project = var.host_project != "" ? var.host_project : var.project
-  name    = var.fw_name_allow_ssh_from_iap
-  network = var.network
+module "iap_tunneling" {
+  source = "./modules/iap-tunneling"
 
-  allow {
-    protocol = "tcp"
-    ports    = ["22"]
-  }
-
-  # https://cloud.google.com/iap/docs/using-tcp-forwarding#before_you_begin
-  # This is the netblock needed to forward to the instances
-  source_ranges           = ["35.235.240.0/20"]
-  target_service_accounts = [google_service_account.bastion_host.email]
-}
-
-resource "google_iap_tunnel_instance_iam_binding" "enable_iap" {
-  count    = var.create_instance_from_template ? 1 : 0
-  provider = google-beta
-  project  = var.project
-  zone     = var.zone
-  instance = google_compute_instance_from_template.bastion_vm[0].name
-  role     = "roles/iap.tunnelResourceAccessor"
-  members  = var.members
+  host_project               = var.host_project
+  project                    = var.project
+  fw_name_allow_ssh_from_iap = var.fw_name_allow_ssh_from_iap
+  network                    = var.network
+  service_account            = google_service_account.bastion_host.email
+  zone                       = var.zone
+  name                       = var.create_instance_from_template ? google_compute_instance_from_template.bastion_vm[0].name : ""
+  members                    = var.members
 }
 
 resource "google_service_account_iam_binding" "bastion_sa_user" {

--- a/modules/iap-tunneling/README.md
+++ b/modules/iap-tunneling/README.md
@@ -84,12 +84,12 @@ the necessary APIs enabled.
 |------|-------------|:----:|:-----:|:-----:|
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP. | string | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID. | string | `""` | no |
-| members | List of IAM resources to allow using the IAP tunnel. | list(string) | `<list>` | no |
-| name | Name of the instance to allow SSH from IAP. If not specified, IAP tunnel user IAM binding will not be created. | string | `""` | no |
+| instances | Names and zones of the instances to allow SSH from IAP. | object | n/a | yes |
+| members | List of IAM resources to allow using the IAP tunnel. | list(string) | n/a | yes |
 | network | Self link of the network to attach the firewall to. | string | n/a | yes |
+| network\_tags | Network tags associated with the instances to allow SSH from IAP. Exactly one of service_accounts or network_tags should be specified. | list(string) | `<list>` | no |
 | project | The project ID to deploy to. | string | n/a | yes |
-| service\_account | Service account email associated with the instance to allow SSH from IAP. | string | n/a | yes |
-| zone | Primary zone of the instance to allow SSH from IAP. | string | `"us-central1-a"` | no |
+| service\_accounts | Service account emails associated with the instances to allow SSH from IAP. Exactly one of service_accounts or network_tags should be specified. | list(string) | `<list>` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/iap-tunneling/README.md
+++ b/modules/iap-tunneling/README.md
@@ -1,0 +1,103 @@
+# iap-tunneling
+
+This module will create firewall rules and IAM bindings to allow TCP forwarding using
+[Identity-Aware Proxy (IAP) Tunneling](https://cloud.google.com/iap/docs/using-tcp-forwarding).
+
+This module will:
+
+- Create firewall rules to allow connections from IAP's TCP forwarding IP addresses to the TCP port
+of your resource's admin service.
+- Create IAM bindings to allow IAP from specified members.
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "iap_tunneling" {
+  source = "terraform-google-modules/bastion-host/google//modules/iap-tunneling"
+
+  project                    = var.project
+  network                    = var.network
+  service_account            = var.service_account
+  zone                       = var.zone
+  name                       = var.name
+  members = [
+    "group:devs@example.com",
+    "user:me@example.com",
+  ]
+}
+```
+
+Once the firewall rule is created, you can search for the newly created firewall rule with something
+similar to the following:
+
+```
+$ gcloud compute firewall-rules list --project my-project --filter="name=allow-ssh-from-iap-to-tunnel"
+NAME                          NETWORK  DIRECTION  PRIORITY  ALLOW   DENY  DISABLED
+allow-ssh-from-iap-to-tunnel  default  INGRESS    1000      tcp:22        False
+```
+
+Once the IAM bindings for IAP-secured Tunnel User is created, you can verify them with something
+similar to the following:
+
+```
+$ curl -H "Authorization: Bearer $(gcloud auth print-access-token)" -X POST \
+https://iap.googleapis.com/v1beta1/projects/my-project/iap_tunnel/zones/us-central1-a/instances/my-instance:getIamPolicy
+{
+  "bindings": [
+    {
+      "role": "roles/iap.tunnelResourceAccessor",
+      "members": [
+        "user:me@example.com"
+      ]
+    }
+  ]
+}
+```
+
+## Requirements
+
+These sections describe requirements for using this module.
+
+### Software
+
+The following dependencies must be available:
+
+- [Terraform][terraform] v0.12
+- [Terraform Provider for GCP][terraform-provider-gcp]
+
+### APIs
+
+A project with the following APIs enabled must be used to host the resources of this module:
+
+- Compute Engine API: `compute.googleapis.com`
+- Cloud Identity-Aware Proxy API: `iap.googleapis.com`
+
+The [Project Factory module][project-factory-module] can be used to provision a project with
+the necessary APIs enabled.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP. | string | `"allow-ssh-from-iap-to-tunnel"` | no |
+| host\_project | The network host project ID. | string | `""` | no |
+| members | List of IAM resources to allow using the IAP tunnel. | list(string) | `<list>` | no |
+| name | Name of the instance to allow SSH from IAP. If not specified, IAP tunnel user IAM binding will not be created. | string | `""` | no |
+| network | Self link of the network to attach the firewall to. | string | n/a | yes |
+| project | The project ID to deploy to. | string | n/a | yes |
+| service\_account | Service account email associated with the instance to allow SSH from IAP. | string | n/a | yes |
+| zone | Primary zone of the instance to allow SSH from IAP. | string | `"us-central1-a"` | no |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Contributing
+
+Refer to the [contribution guidelines](./CONTRIBUTING.md) for
+information on contributing to this module.
+
+[project-factory-module]: https://registry.terraform.io/modules/terraform-google-modules/project-factory/google
+[terraform-provider-gcp]: https://www.terraform.io/docs/providers/google/index.html
+[terraform]: https://www.terraform.io/downloads.html

--- a/modules/iap-tunneling/main.tf
+++ b/modules/iap-tunneling/main.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_firewall" "allow_from_iap_to_instances" {
+  project = var.host_project != "" ? var.host_project : var.project
+  name    = var.fw_name_allow_ssh_from_iap
+  network = var.network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  # https://cloud.google.com/iap/docs/using-tcp-forwarding#before_you_begin
+  # This is the netblock needed to forward to the instances
+  source_ranges = ["35.235.240.0/20"]
+
+  # Use service account instead of network tags to identify the instance to be more restrict and explict.
+  # https://cloud.google.com/vpc/docs/firewalls#service-accounts-vs-tags
+  target_service_accounts = [var.service_account]
+}
+
+resource "google_iap_tunnel_instance_iam_binding" "enable_iap" {
+  count = (var.name != "" && length(var.members) != 0) ? 1 : 0
+
+  provider = google-beta
+  project  = var.project
+  zone     = var.zone
+  instance = var.name
+  role     = "roles/iap.tunnelResourceAccessor"
+  members  = var.members
+}

--- a/modules/iap-tunneling/variables.tf
+++ b/modules/iap-tunneling/variables.tf
@@ -32,22 +32,27 @@ variable "network" {
   description = "Self link of the network to attach the firewall to."
 }
 
-variable "service_account" {
-  description = "Service account email associated with the instance to allow SSH from IAP."
+variable "service_accounts" {
+  description = "Service account emails associated with the instances to allow SSH from IAP. Exactly one of service_accounts or network_tags should be specified."
+  type        = list(string)
+  default     = []
 }
 
-variable "zone" {
-  description = "Primary zone of the instance to allow SSH from IAP."
-  default     = "us-central1-a"
+variable "network_tags" {
+  description = "Network tags associated with the instances to allow SSH from IAP. Exactly one of service_accounts or network_tags should be specified."
+  type        = list(string)
+  default     = []
 }
 
-variable "name" {
-  description = "Name of the instance to allow SSH from IAP. If not specified, IAP tunnel user IAM binding will not be created."
-  default     = ""
+variable "instances" {
+  type = list(object({
+    name = string
+    zone = string
+  }))
+  description = "Names and zones of the instances to allow SSH from IAP."
 }
 
 variable "members" {
   description = "List of IAM resources to allow using the IAP tunnel."
   type        = list(string)
-  default     = []
 }

--- a/modules/iap-tunneling/variables.tf
+++ b/modules/iap-tunneling/variables.tf
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "host_project" {
+  description = "The network host project ID."
+  default     = ""
+}
+
+variable "project" {
+  description = "The project ID to deploy to."
+}
+
+variable "fw_name_allow_ssh_from_iap" {
+  description = "Firewall rule name for allowing SSH from IAP."
+  default     = "allow-ssh-from-iap-to-tunnel"
+}
+
+variable "network" {
+  description = "Self link of the network to attach the firewall to."
+}
+
+variable "service_account" {
+  description = "Service account email associated with the instance to allow SSH from IAP."
+}
+
+variable "zone" {
+  description = "Primary zone of the instance to allow SSH from IAP."
+  default     = "us-central1-a"
+}
+
+variable "name" {
+  description = "Name of the instance to allow SSH from IAP. If not specified, IAP tunnel user IAM binding will not be created."
+  default     = ""
+}
+
+variable "members" {
+  description = "List of IAM resources to allow using the IAP tunnel."
+  type        = list(string)
+  default     = []
+}

--- a/test/fixtures/iap_tunneling/main.tf
+++ b/test/fixtures/iap_tunneling/main.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "iap_bastion_example" {
+  source   = "../../../examples/iap_tunneling"
+  project  = var.project_id
+  members  = var.members
+  instance = var.instance
+  zone     = var.zone
+}

--- a/test/fixtures/iap_tunneling/main.tf
+++ b/test/fixtures/iap_tunneling/main.tf
@@ -15,9 +15,12 @@
  */
 
 module "iap_bastion_example" {
-  source   = "../../../examples/iap_tunneling"
-  project  = var.project_id
-  members  = var.members
+  source  = "../../../examples/iap_tunneling"
+  project = var.project_id
+  members = [
+    "serviceAccount:${var.service_account.email}",
+  ]
   instance = var.instance
+  region   = var.region
   zone     = var.zone
 }

--- a/test/fixtures/iap_tunneling/outputs.tf
+++ b/test/fixtures/iap_tunneling/outputs.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value = var.project_id
+}
+
+output "instance" {
+  value = var.instance
+}
+
+output "zone" {
+  value = var.zone
+}

--- a/test/fixtures/iap_tunneling/variables.tf
+++ b/test/fixtures/iap_tunneling/variables.tf
@@ -16,15 +16,23 @@
 
 variable "project_id" {}
 
-variable "members" {
-  description = "List of members in the standard GCP form: user:{email}, serviceAccount:{email}, group:{email}"
-  type        = list(string)
+variable "instance" {
+  default = "iap-test-instance"
 }
 
-variable "instance" {
-  description = "Name of the testing VM instance to create and allow SSH from IAP."
+variable "region" {
+  default = "us-west1"
 }
 
 variable "zone" {
-  description = "Zone of the example VM instance to create and allow SSH from IAP."
+  default = "us-west1-a"
+}
+
+variable "service_account" {
+  default = null
+  type = object({
+    email  = string
+    scopes = list(string)
+  })
+  description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }

--- a/test/fixtures/iap_tunneling/variables.tf
+++ b/test/fixtures/iap_tunneling/variables.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {}
+
+variable "members" {
+  description = "List of members in the standard GCP form: user:{email}, serviceAccount:{email}, group:{email}"
+  type        = list(string)
+}
+
+variable "instance" {
+  description = "Name of the testing VM instance to create and allow SSH from IAP."
+}
+
+variable "zone" {
+  description = "Zone of the example VM instance to create and allow SSH from IAP."
+}

--- a/test/integration/iap_tunneling/controls/iap.rb
+++ b/test/integration/iap_tunneling/controls/iap.rb
@@ -35,7 +35,7 @@ control "IAP Tunneling" do
   end
 
   describe "SSH Firewall Rule" do
-    subject { command("gcloud --project #{project_id} compute firewall-rules describe allow-ssh-from-iap-to-tunnel --format json") }
+    subject { command("gcloud --project #{project_id} compute firewall-rules describe test-allow-ssh-from-iap-to-tunnel --format json") }
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
     let!(:data) { JSON.parse(subject.stdout) if subject.exit_status == 0 }

--- a/test/integration/iap_tunneling/controls/iap.rb
+++ b/test/integration/iap_tunneling/controls/iap.rb
@@ -1,0 +1,51 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = attribute('project_id')
+instance = attribute('instance')
+zone = attribute('zone')
+
+control "IAP Tunneling" do
+  title "Simple Configuration"
+  describe "Instance configuration" do
+    subject { command("gcloud --project=#{project_id} compute instances describe #{instance} --format=json --zone #{zone}") }
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+    let!(:data) { JSON.parse(subject.stdout) if subject.exit_status == 0 }
+
+    it "should be running" do
+      expect(data['status']).to eq('RUNNING')
+    end
+
+    it "should have correct OS Login config" do
+      entry = data['metadata']['items'].find { |i| i['key'] == "enable-oslogin" }
+      expect(entry['value']).to eq('TRUE')
+    end
+  end
+
+  describe "SSH Firewall Rule" do
+    subject { command("gcloud --project #{project_id} compute firewall-rules describe allow-ssh-from-iap-to-tunnel --format json") }
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+    let!(:data) { JSON.parse(subject.stdout) if subject.exit_status == 0 }
+
+    it "should allow SSH ingress from IAP" do
+      expect(data['sourceRanges'][0]).to eq('35.235.240.0/20')
+      expect(data['direction']).to eq('INGRESS')
+      expect(data['targetServiceAccounts'][0]).to match("#{instance}@#{project_id}.iam.gserviceaccount.com")
+      expect(data['allowed'][0]['ports'][0]).to eq("22")
+    end
+  end
+
+end

--- a/test/integration/iap_tunneling/inspec.yml
+++ b/test/integration/iap_tunneling/inspec.yml
@@ -1,0 +1,26 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: iap_tunneling
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: instance
+    required: true
+    type: string
+  - name: zone
+    required: true
+    type: string


### PR DESCRIPTION
#29 

I didn't add the option to use network tags to indicate the vm instance as I feel using the service account is much more restrict and explict. Also see https://cloud.google.com/vpc/docs/firewalls#service-accounts-vs-tags