### PR TITLE
Bumped google provider version to 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Bumped Google provider to 3.4
 - Pulled IAP Tunnelling into separate module [#29]
 
 ## [2.0.0]

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@
 terraform {
   required_version = "~> 0.12"
   required_providers {
-    google      = "~> 2.17"
-    google-beta = "~> 2.17"
+    google      = "~> 3.4"
+    google-beta = "~> 3.4"
   }
 }


### PR DESCRIPTION
Need to bump the version to work with the vault module.