### PR TITLE
Cannot pass additional roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ provision a project with the necessary APIs enabled.
 | project | The project ID to deploy to | string | n/a | yes |
 | random\_role\_id | Enables role random id generation. | bool | `"true"` | no |
 | region | The primary region where the bastion host will live | string | `"us-central1"` | no |
-| scopes | List of scopes to attach to the bastion host | list | `<list>` | no |
+| scopes | List of scopes to attach to the bastion host | list(string) | `<list>` | no |
 | service\_account\_name | Account ID for the service account | string | `"bastion"` | no |
-| service\_account\_roles | List of IAM roles to assign to the service account. | list | `<list>` | no |
-| service\_account\_roles\_supplemental | An additional list of roles to assign to the bastion if desired | list | `<list>` | no |
+| service\_account\_roles | List of IAM roles to assign to the service account. | list(string) | `<list>` | no |
+| service\_account\_roles\_supplemental | An additional list of roles to assign to the bastion if desired | list(string) | `<list>` | no |
 | shielded\_vm | Enable shielded VM on the bastion host (recommended) | bool | `"true"` | no |
 | startup\_script | Render a startup script with a template. | string | `""` | no |
 | subnet | Self link for the subnet on which the Bastion should live. Can be private when using IAP | string | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -15,74 +15,97 @@
  */
 
 variable "image_family" {
+  type = string
+
   description = "Source image family for the Bastion."
   default     = "centos-7"
 }
 
 variable "image_project" {
+  type = string
+
   description = "Project where the source image for the Bastion comes from"
   default     = "gce-uefi-images"
 }
 
 variable "create_instance_from_template" {
+  type = bool
+
   description = "Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG"
   default     = true
-  type        = bool
 }
 
 
 variable "tags" {
-  type        = list(string)
+  type = list(string)
+
   description = "Network tags, provided as a list"
   default     = []
 }
 
 variable "labels" {
+  type = map
+
   description = "Key-value map of labels to assign to the bastion host"
-  type        = map
   default     = {}
 }
 
 variable "machine_type" {
+  type        = string
   description = "Instance type for the Bastion host"
   default     = "n1-standard-1"
 }
 
 variable "members" {
+  type = list(string)
+
   description = "List of IAM resources to allow access to the bastion host"
-  type        = list(string)
   default     = []
 }
 
 variable "name" {
+  type = string
+
   description = "Name of the Bastion instance"
   default     = "bastion-vm"
 }
 
 variable "network" {
+  type = string
+
   description = "Self link for the network on which the Bastion should live"
 }
 
 variable "project" {
+  type = string
+
   description = "The project ID to deploy to"
 }
 
 variable "host_project" {
+  type = string
+
   description = "The network host project ID"
   default     = ""
 }
 
 variable "region" {
+  type = string
+
   description = "The primary region where the bastion host will live"
   default     = "us-central1"
 }
 
 variable "scopes" {
+  type = list(string)
+
   description = "List of scopes to attach to the bastion host"
   default     = ["cloud-platform"]
 }
 
 variable "service_account_roles" {
+  type = list(string)
+
   description = "List of IAM roles to assign to the service account."
   default = [
     "roles/logging.logWriter",
@@ -93,42 +116,56 @@ variable "service_account_roles" {
 }
 
 variable "service_account_roles_supplemental" {
+  type = list(string)
+
   description = "An additional list of roles to assign to the bastion if desired"
   default     = []
 }
 
 variable "service_account_name" {
+  type = string
+
   description = "Account ID for the service account"
   default     = "bastion"
 }
 
 variable "shielded_vm" {
+  type = bool
+
   description = "Enable shielded VM on the bastion host (recommended)"
   default     = true
-  type        = bool
 }
 
 variable "startup_script" {
+  type = string
+
   description = "Render a startup script with a template."
   default     = ""
 }
 
 variable "subnet" {
+  type = string
+
   description = "Self link for the subnet on which the Bastion should live. Can be private when using IAP"
 }
 
 variable "zone" {
+  type = string
+
   description = "The primary zone where the bastion host will live"
   default     = "us-central1-a"
 }
 
 variable "random_role_id" {
+  type = bool
+
   description = "Enables role random id generation."
-  type        = bool
   default     = true
 }
 
 variable "fw_name_allow_ssh_from_iap" {
+  type = string
+
   description = "Firewall rule name for allowing SSH from IAP"
   default     = "allow-ssh-from-iap-to-tunnel"
 }


### PR DESCRIPTION
Issue: if the variable service_account_roles_supplemental is passed to the module the interpolation breaks due to missing variable type.

Fix: Set the variable type for all variables and standardize always as the first parameter.

Terraform version: 0.12.10
Error:
```
google_iap_tunnel_instance_iam_binding.enable_iap[0]: Refreshing state... [id=projects/268656762092/iap_tunnel/zones/us-central1-a/instances/bastion-vm/roles/iap.tunnelResourceAccessor]

Error: Invalid function argument

  on main.tf line 110, in resource "google_project_iam_member" "bastion_sa_bindings":
 108: 
 109: 
 110:     var.service_account_roles_supplemental,
 111: 
    |----------------
    | var.service_account_roles_supplemental is "[\"roles/storage.objectViewer\",\"roles/storage.objectCreator\"]"

Invalid value for "seqs" parameter: all arguments must be lists or tuples; got
string.
```