### PR TITLE
set source image for bastion host if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ provision a project with the necessary APIs enabled.
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | bool | `"true"` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | string | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID | string | `""` | no |
+| image | Source image for the Bastion. If image is not specified, image_family will be used (which is the default). | string | `""` | no |
 | image\_family | Source image family for the Bastion. | string | `"centos-7"` | no |
 | image\_project | Project where the source image for the Bastion comes from | string | `"gce-uefi-images"` | no |
 | labels | Key-value map of labels to assign to the bastion host | map | `<map>` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "instance_template" {
     scopes = var.scopes
   }
   enable_shielded_vm   = var.shielded_vm
+  source_image         = var.image
   source_image_family  = var.image_family
   source_image_project = var.image_project
   startup_script       = var.startup_script

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+variable "image" {
+  type = string
+
+  description = "Source image for the Bastion. If image is not specified, image_family will be used (which is the default)."
+  default     = ""
+}
+
 variable "image_family" {
   type = string
 


### PR DESCRIPTION
We would like be able to specify the source image for the bastion host. 

If variable `image` not set, the latest public image will be used as implemented in:
https://github.com/terraform-google-modules/terraform-google-vm/tree/master/modules/instance_template