### PR TITLE
Optional Service Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ provision a project with the necessary APIs enabled.
 | random\_role\_id | Enables role random id generation. | bool | `"true"` | no |
 | region | The primary region where the bastion host will live | string | `"us-central1"` | no |
 | scopes | List of scopes to attach to the bastion host | list(string) | `<list>` | no |
-| service\_account\_email | If set, the resources regarding service account and its permissions won't be created. It must be an already existing service account e-mail with the roles in the variable service_account_roles associated with it. | string | `""` | no |
+| service\_account\_email | If set, the service account and its permissions will not be created. The service account being passed in should have at least the roles listed in the `service_account_roles` variable so that logging and OS Login work as expected. | string | `""` | no |
 | service\_account\_name | Account ID for the service account | string | `"bastion"` | no |
 | service\_account\_roles | List of IAM roles to assign to the service account. | list(string) | `<list>` | no |
 | service\_account\_roles\_supplemental | An additional list of roles to assign to the bastion if desired | list(string) | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ provision a project with the necessary APIs enabled.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | bool | `"true"` | no |
+| create\_service\_account | Whether to create the service account or not. If false, no service account is created, but the roles keep being binded | bool | `"true"` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | string | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID | string | `""` | no |
 | image | Source image for the Bastion. If image is not specified, image_family will be used (which is the default). | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ provision a project with the necessary APIs enabled.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | bool | `"true"` | no |
-| create\_service\_account | Whether to create the service account or not. If false, no service account is created, but the roles keep being binded | bool | `"true"` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | string | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID | string | `""` | no |
 | image | Source image for the Bastion. If image is not specified, image_family will be used (which is the default). | string | `""` | no |
@@ -78,6 +77,7 @@ provision a project with the necessary APIs enabled.
 | random\_role\_id | Enables role random id generation. | bool | `"true"` | no |
 | region | The primary region where the bastion host will live | string | `"us-central1"` | no |
 | scopes | List of scopes to attach to the bastion host | list(string) | `<list>` | no |
+| service\_account\_email | If set, the resources regarding service account and its permissions won't be created. It must be an already existing service account e-mail with the roles in the variable service_account_roles associated with it. | string | `""` | no |
 | service\_account\_name | Account ID for the service account | string | `"bastion"` | no |
 | service\_account\_roles | List of IAM roles to assign to the service account. | list(string) | `<list>` | no |
 | service\_account\_roles\_supplemental | An additional list of roles to assign to the bastion if desired | list(string) | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,9 @@ resource "random_id" "random_role_id_suffix" {
 }
 
 locals {
-  base_role_id = "osLoginProjectGet"
+  base_role_id          = "osLoginProjectGet"
+  service_account_email = var.create_service_account ? google_service_account.bastion_host[0].email : format("%s@%s.iam.gserviceaccount.com", var.service_account_name, var.project)
+  service_account_id    = var.create_service_account ? google_service_account.bastion_host[0].id : format("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", var.project, var.service_account_name, var.project)
   temp_role_id = var.random_role_id ? format(
     "%s_%s",
     local.base_role_id,

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ locals {
 }
 
 resource "google_service_account" "bastion_host" {
+  count        = var.create_service_account ? 1 : 0
   project      = var.project
   account_id   = var.service_account_name
   display_name = "Service Account for Bastion"
@@ -92,6 +93,7 @@ module "iap_tunneling" {
 }
 
 resource "google_service_account_iam_binding" "bastion_sa_user" {
+  count              = var.create_service_account ? 1 : 0
   service_account_id = google_service_account.bastion_host.id
   role               = "roles/iam.serviceAccountUser"
   members            = var.members

--- a/main.tf
+++ b/main.tf
@@ -100,10 +100,10 @@ resource "google_service_account_iam_binding" "bastion_sa_user" {
 }
 
 resource "google_project_iam_member" "bastion_sa_bindings" {
-  for_each = toset(compact(concat(
+  for_each = var.create_service_account ? toset(compact(concat(
     var.service_account_roles,
     var.service_account_roles_supplemental,
-  )))
+  ))) : []
 
   project = var.project
   role    = each.key

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ module "instance_template" {
   machine_type = var.machine_type
   subnetwork   = var.subnet
   service_account = {
-    email  = google_service_account.bastion_host.email
+    email  = local.service_account_email
     scopes = var.scopes
   }
   enable_shielded_vm   = var.shielded_vm
@@ -84,7 +84,7 @@ module "iap_tunneling" {
   project                    = var.project
   fw_name_allow_ssh_from_iap = var.fw_name_allow_ssh_from_iap
   network                    = var.network
-  service_accounts           = [google_service_account.bastion_host.email]
+  service_accounts           = [local.service_account_email]
   instances = var.create_instance_from_template ? [{
     name = google_compute_instance_from_template.bastion_vm[0].name
     zone = var.zone
@@ -94,7 +94,7 @@ module "iap_tunneling" {
 
 resource "google_service_account_iam_binding" "bastion_sa_user" {
   count              = var.create_service_account ? 1 : 0
-  service_account_id = google_service_account.bastion_host.id
+  service_account_id = local.service_account_id
   role               = "roles/iam.serviceAccountUser"
   members            = var.members
 }
@@ -107,7 +107,7 @@ resource "google_project_iam_member" "bastion_sa_bindings" {
 
   project = var.project
   role    = each.key
-  member  = "serviceAccount:${google_service_account.bastion_host.email}"
+  member  = "serviceAccount:${local.service_account_email}"
 }
 
 # If you are practicing least privilege, to enable instance level OS Login, you
@@ -124,6 +124,5 @@ resource "google_project_iam_custom_role" "compute_os_login_viewer" {
 resource "google_project_iam_member" "bastion_oslogin_bindings" {
   project = var.project
   role    = "projects/${var.project}/roles/${google_project_iam_custom_role.compute_os_login_viewer.role_id}"
-  member  = "serviceAccount:${google_service_account.bastion_host.email}"
+  member  = "serviceAccount:${local.service_account_email}"
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@
  */
 output "service_account" {
   description = "The email for the service account created for the bastion host"
-  value       = google_service_account.bastion_host.email
+  value       = local.service_account_email
 }
 
 output "hostname" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,6 @@ variable "create_instance_from_template" {
   default     = true
 }
 
-variable "create_service_account" {
-  type = bool
-
-  description = "Whether to create the service account or not. If false, no service account is created, but the roles keep being binded"
-  default     = true
-}
-
 variable "tags" {
   type = list(string)
 
@@ -146,6 +139,13 @@ variable "service_account_name" {
 
   description = "Account ID for the service account"
   default     = "bastion"
+}
+
+variable "service_account_email" {
+  type = string
+
+  description = "If set, the resources regarding service account and its permissions won't be created. It must be an already existing service account e-mail with the roles in the variable service_account_roles associated with it."
+  default     = ""
 }
 
 variable "shielded_vm" {

--- a/variables.tf
+++ b/variables.tf
@@ -144,12 +144,7 @@ variable "service_account_name" {
 variable "service_account_email" {
   type = string
 
-  description = <<EOT
-If set, the service account and its permissions will not be created.
-The service account being passed in should have at least the roles listed
-in the `service_account_roles` variable so that logging and OS Login work
-as expected."
-EOT
+  description = "If set, the service account and its permissions will not be created. The service account being passed in should have at least the roles listed in the `service_account_roles` variable so that logging and OS Login work as expected."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,13 @@ variable "create_instance_from_template" {
   default     = true
 }
 
+variable "create_service_account" {
+  type = bool
+
+  description = "Whether to create the service account or not. If false, no service account is created, but the roles keep being binded"
+  default     = true
+}
+
 variable "tags" {
   type = list(string)
 

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,12 @@ variable "service_account_name" {
 variable "service_account_email" {
   type = string
 
-  description = "If set, the resources regarding service account and its permissions won't be created. It must be an already existing service account e-mail with the roles in the variable service_account_roles associated with it."
+  description = <<EOT
+If set, the service account and its permissions will not be created.
+The service account being passed in should have at least the roles listed
+in the `service_account_roles` variable so that logging and OS Login work
+as expected."
+EOT
   default     = ""
 }
 


### PR DESCRIPTION
This Pull Request adds a new variable called create_service_account and use it to determine whether the service account and its permissions are going to be created or not.

This is useful when another team takes care of the IAM or it's being deployed by another stack.

I've tested both deploy from scratch and changing from specified service account to auto created one. I mean, updated the variable create_service_account from false to true.