### PR TITLE
BREAKING CHANGE: update provider and instance template version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ provision a project with the necessary APIs enabled.
 | network | Self link for the network on which the Bastion should live | string | n/a | yes |
 | project | The project ID to deploy to | string | n/a | yes |
 | random\_role\_id | Enables role random id generation. | bool | `"true"` | no |
-| region | The primary region where the bastion host will live | string | `"us-central1"` | no |
 | scopes | List of scopes to attach to the bastion host | list(string) | `<list>` | no |
 | service\_account\_email | If set, the service account and its permissions will not be created. The service account being passed in should have at least the roles listed in the `service_account_roles` variable so that logging and OS Login work as expected. | string | `""` | no |
 | service\_account\_name | Account ID for the service account | string | `"bastion"` | no |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ module "iap_bastion" {
   source = "terraform-google-modules/bastion-host/google"
 
   project = var.project
-  region = var.region
   zone = var.zone
   network = google_compute_network.net.self_link
   subnet = google_compute_subnetwork.net.self_link

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "google_service_account" "bastion_host" {
 
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "1.1.0"
+  version = "~> 3.0"
 
   name_prefix  = var.name_prefix
   project_id   = var.project

--- a/modules/bastion-group/README.md
+++ b/modules/bastion-group/README.md
@@ -75,6 +75,7 @@ provision a project with the necessary APIs enabled.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | string | `"allow-ssh-from-iap-to-bastion-group"` | no |
+| health\_check | Health check config for the mig. | object | `<map>` | no |
 | host\_project | The network host project ID | string | `""` | no |
 | image\_family | Source image family for the Bastion. | string | `"centos-7"` | no |
 | image\_project | Project where the source image for the Bastion comes from | string | `"gce-uefi-images"` | no |

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -42,7 +42,7 @@ module "iap_bastion" {
 
 module "mig" {
   source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "1.3.0"
+  version = "~> 3.0"
 
   project_id  = var.project
   region      = var.region

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -44,14 +44,14 @@ module "mig" {
   source  = "terraform-google-modules/vm/google//modules/mig"
   version = "~> 3.0"
 
-  project_id  = var.project
-  region      = var.region
-  target_size = var.target_size
-  hostname    = var.name
-  instance_template      = module.iap_bastion.instance_template
+  project_id        = var.project
+  region            = var.region
+  target_size       = var.target_size
+  hostname          = var.name
+  instance_template = module.iap_bastion.instance_template
 
   health_check = {
-    type   = "tcp"
+    type                = "tcp"
     initial_delay_sec   = 30
     check_interval_sec  = 30
     healthy_threshold   = 1

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -41,10 +41,8 @@ module "iap_bastion" {
 }
 
 module "mig" {
-  source = "git::https://github.com/terraform-google-modules/terraform-google-vm.git?ref=umairidris-patch-1"
-
-  #source  = "terraform-google-modules/vm/google//modules/mig"
-  #version = "~> 3.0"
+  source  = "terraform-google-modules/vm/google//modules/mig"
+  version = "~> 3.0"
 
   project_id        = var.project
   region            = var.region

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -47,24 +47,8 @@ module "mig" {
   region            = var.region
   target_size       = var.target_size
   hostname          = var.name
+  health_check      = var.health_check
   instance_template = module.iap_bastion.instance_template
-
-  health_check = {
-    type                = "tcp"
-    initial_delay_sec   = 30
-    check_interval_sec  = 30
-    healthy_threshold   = 1
-    timeout_sec         = 10
-    unhealthy_threshold = 5
-    response            = ""
-    proxy_header        = "NONE"
-    port                = 22
-    request             = ""
-
-    # Unused fields.
-    request_path = ""
-    host         = ""
-  }
 }
 
 resource "google_compute_firewall" "allow_from_iap_to_bastion" {

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -26,7 +26,6 @@ module "iap_bastion" {
   network                            = var.network
   project                            = var.project
   host_project                       = var.host_project
-  region                             = var.region
   scopes                             = var.scopes
   service_account_name               = var.service_account_name
   service_account_roles              = var.service_account_roles

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -61,7 +61,9 @@ module "mig" {
     proxy_header        = "NONE"
     port                = 22
     request             = ""
-    request_path        = "/"
+
+    # Unused fields.
+    request_path        = ""
     host                = ""
   }
 }

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -41,8 +41,10 @@ module "iap_bastion" {
 }
 
 module "mig" {
-  source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "~> 3.0"
+  source = "git::https://github.com/terraform-google-modules/terraform-google-vm.git?ref=umairidris-patch-1"
+
+  #source  = "terraform-google-modules/vm/google//modules/mig"
+  #version = "~> 3.0"
 
   project_id        = var.project
   region            = var.region

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -63,8 +63,8 @@ module "mig" {
     request             = ""
 
     # Unused fields.
-    request_path        = ""
-    host                = ""
+    request_path = ""
+    host         = ""
   }
 }
 

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -48,10 +48,22 @@ module "mig" {
   region      = var.region
   target_size = var.target_size
   hostname    = var.name
-  hc_port     = 22
-
-  tcp_healthcheck_enable = true
   instance_template      = module.iap_bastion.instance_template
+
+  health_check = {
+    type   = "tcp"
+    initial_delay_sec   = 30
+    check_interval_sec  = 30
+    healthy_threshold   = 1
+    timeout_sec         = 10
+    unhealthy_threshold = 5
+    response            = ""
+    proxy_header        = "NONE"
+    port                = 22
+    request             = ""
+    request_path        = "/"
+    host                = ""
+  }
 }
 
 resource "google_compute_firewall" "allow_from_iap_to_bastion" {

--- a/modules/bastion-group/variables.tf
+++ b/modules/bastion-group/variables.tf
@@ -66,7 +66,7 @@ variable "project" {
 
 variable "health_check" {
   description = "Health check config for the mig."
-  type        = object({
+  type = object({
     type                = string
     initial_delay_sec   = number
     check_interval_sec  = number
@@ -79,8 +79,8 @@ variable "health_check" {
     request             = string
 
     # Unused fields.
-    request_path        = string
-    host                = string
+    request_path = string
+    host         = string
   })
   default = {
     type                = "tcp"

--- a/modules/bastion-group/variables.tf
+++ b/modules/bastion-group/variables.tf
@@ -64,6 +64,42 @@ variable "project" {
   description = "The project ID to deploy to"
 }
 
+variable "health_check" {
+  description = "Health check config for the mig."
+  type        = object({
+    type                = string
+    initial_delay_sec   = number
+    check_interval_sec  = number
+    healthy_threshold   = number
+    timeout_sec         = number
+    unhealthy_threshold = number
+    response            = string
+    proxy_header        = string
+    port                = number
+    request             = string
+
+    # Unused fields.
+    request_path        = string
+    host                = string
+  })
+  default = {
+    type                = "tcp"
+    initial_delay_sec   = 30
+    check_interval_sec  = 30
+    healthy_threshold   = 1
+    timeout_sec         = 10
+    unhealthy_threshold = 5
+    response            = ""
+    proxy_header        = "NONE"
+    port                = 22
+    request             = ""
+
+    # Unused fields.
+    request_path = ""
+    host         = ""
+  }
+}
+
 variable "host_project" {
   description = "The network host project ID"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -101,13 +101,6 @@ variable "host_project" {
   default     = ""
 }
 
-variable "region" {
-  type = string
-
-  description = "The primary region where the bastion host will live"
-  default     = "us-central1"
-}
-
 variable "scopes" {
   type = list(string)
 


### PR DESCRIPTION
We need to make a new breaking change release because the provider version was changed in 

https://github.com/terraform-google-modules/terraform-google-bastion-host/commit/a5979be01e394fdee2d9f8355feb28c620f41efc#diff-a4a7a59545ca3091e2f47a9f2b5543ab.

Use this opportunity to update the instance template version as well and cleanup unused var.