### PR TITLE
Adding additional ports parameter, optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ provision a project with the necessary APIs enabled.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | list(string) | `<list>` | no |
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | bool | `"true"` | no |
 | disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ module "iap_tunneling" {
 
   host_project               = var.host_project
   project                    = var.project
+  additional_ports           = var.additional_ports
   fw_name_allow_ssh_from_iap = var.fw_name_allow_ssh_from_iap
   network                    = var.network
   service_accounts           = [local.service_account_email]

--- a/modules/iap-tunneling/README.md
+++ b/modules/iap-tunneling/README.md
@@ -86,6 +86,7 @@ the necessary APIs enabled.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | list(string) | `<list>` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP. | string | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID. | string | `""` | no |
 | instances | Names and zones of the instances to allow SSH from IAP. | object | n/a | yes |

--- a/modules/iap-tunneling/main.tf
+++ b/modules/iap-tunneling/main.tf
@@ -21,7 +21,7 @@ resource "google_compute_firewall" "allow_from_iap_to_instances" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22"]
+    ports    = toset(concat(["22"], var.additional_ports))
   }
 
   # https://cloud.google.com/iap/docs/using-tcp-forwarding#before_you_begin

--- a/modules/iap-tunneling/variables.tf
+++ b/modules/iap-tunneling/variables.tf
@@ -56,3 +56,9 @@ variable "members" {
   description = "List of IAM resources to allow using the IAP tunnel."
   type        = list(string)
 }
+
+variable "additional_ports" {
+  description = "A list of additional ports/ranges to open access to on the instances from IAP."
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,12 @@ variable "fw_name_allow_ssh_from_iap" {
   default     = "allow-ssh-from-iap-to-tunnel"
 }
 
+variable "additional_ports" {
+  description = "A list of additional ports/ranges to open access to on the instances from IAP."
+  type        = list(string)
+  default     = []
+}
+
 variable "disk_size_gb" {
   description = "Boot disk size in GB"
   default     = 100


### PR DESCRIPTION
1. Adds an additional ports variable in the iap_tunneling module, defaulted empty.
2. Adds nested functions in resource composition to create a set of unique ports / ranges.
3. Implements the same additional_ports variable in the module's root, and passes it through to the iap_tunneling submodule.
4. Updates documentation.