### PR TITLE
added option to specify the fw rule name for ssh to health checks

### DIFF
--- a/modules/bastion-group/README.md
+++ b/modules/bastion-group/README.md
@@ -74,6 +74,7 @@ provision a project with the necessary APIs enabled.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| fw\_name\_allow\_ssh\_from\_health\_check\_cidrs | Firewall rule name for allowing Health Checks | string | `"allow-ssh-from-health-check-cidrs"` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | string | `"allow-ssh-from-iap-to-bastion-group"` | no |
 | health\_check | Health check config for the mig. | object | `<map>` | no |
 | host\_project | The network host project ID | string | `""` | no |

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -53,7 +53,7 @@ module "mig" {
 
 resource "google_compute_firewall" "allow_from_iap_to_bastion" {
   project = var.host_project != "" ? var.host_project : var.project
-  name    = "allow-ssh-from-health-check-cidrs"
+  name    = var.fw_name_allow_ssh_from_health_check_cidrs
   network = var.network
 
   allow {

--- a/modules/bastion-group/variables.tf
+++ b/modules/bastion-group/variables.tf
@@ -161,6 +161,11 @@ variable "random_role_id" {
   default     = true
 }
 
+variable "fw_name_allow_ssh_from_health_check_cidrs" {
+  description = "Firewall rule name for allowing Health Checks"
+  default     = "allow-ssh-from-health-check-cidrs"
+}
+
 variable "fw_name_allow_ssh_from_iap" {
   description = "Firewall rule name for allowing SSH from IAP"
   default     = "allow-ssh-from-iap-to-bastion-group"


### PR DESCRIPTION
There was already an option to specify the firewall rule name for ssh from IAP. This patch adds an additional variable so the user can also specify the firewall rule name for allowing the ssh health checks from GCP.