### PR TITLE
Support additional metadata for instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ provision a project with the necessary APIs enabled.
 | labels | Key-value map of labels to assign to the bastion host | map | `<map>` | no |
 | machine\_type | Instance type for the Bastion host | string | `"n1-standard-1"` | no |
 | members | List of IAM resources to allow access to the bastion host | list(string) | `<list>` | no |
+| metadata | Key-value map of additional metadata to assign to the instances | map(string) | `<map>` | no |
 | name | Name of the Bastion instance | string | `"bastion-vm"` | no |
 | name\_prefix | Name prefix for instance template | string | `"bastion-instance-template"` | no |
 | network | Self link for the network on which the Bastion should live | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -64,9 +64,12 @@ module "instance_template" {
 
   tags = var.tags
 
-  metadata = {
-    enable-oslogin = "TRUE"
-  }
+  metadata = merge(
+    var.metadata,
+    {
+      enable-oslogin = "TRUE"
+    }
+  )
 }
 
 resource "google_compute_instance_from_template" "bastion_vm" {

--- a/variables.tf
+++ b/variables.tf
@@ -197,3 +197,9 @@ variable "disk_type" {
   description = "Boot disk type, can be either pd-ssd, local-ssd, or pd-standard"
   default     = "pd-standard"
 }
+
+variable "metadata" {
+  type        = map(string)
+  description = "Key-value map of additional metadata to assign to the instances"
+  default     = {}
+}


### PR DESCRIPTION
I need the option that the bastion host stores its ssh host keys in the metadata server. This is supported in GCP via [guest attributes](https://cloud.google.com/compute/docs/storing-retrieving-metadata#guest_attributes). To enable this we have to set the metadata key `enable-guest-attributes = "TRUE"`.

This PR simply add support to add custom metadata to bastion instances.

Signed-off-by: Timo Zingel <timo.zingel@joblift.de>