### PR TITLE
fix: pass labels into instance template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "instance_template" {
   source_image_project = var.image_project
   startup_script       = var.startup_script
 
-  tags = var.tags
+  tags   = var.tags
   labels = var.labels
 
   metadata = merge(

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ module "instance_template" {
   startup_script       = var.startup_script
 
   tags = var.tags
+  labels = var.labels
 
   metadata = merge(
     var.metadata,


### PR DESCRIPTION
Passes the `labels` variable into the instance template module to apply it to the bastion instance