### PR TITLE
feat: Add option for creating firewall rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If the user does not share the same domain as the org the bastion is in, you wil
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configs for network, nat\_ip and DNS | <pre>list(object({<br>    network_tier           = string<br>    nat_ip                 = string<br>    public_ptr_domain_name = string<br>  }))</pre> | <pre>[<br>  {<br>    "nat_ip": "",<br>    "network_tier": "PREMIUM",<br>    "public_ptr_domain_name": ""<br>  }<br>]</pre> | no |
 | additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | `list(string)` | `[]` | no |
+| create\_firewall\_rule | If we need to create the firewall rule or not. | `bool` | `true` | no |
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | `bool` | `true` | no |
 | disk\_size\_gb | Boot disk size in GB | `number` | `100` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,8 @@ module "iap_tunneling" {
     name = try(google_compute_instance_from_template.bastion_vm[0].name, "")
     zone = var.zone
   }] : []
-  members = var.members
+  members              = var.members
+  create_firewall_rule = var.create_firewall_rule
 }
 
 resource "google_service_account_iam_binding" "bastion_sa_user" {

--- a/modules/iap-tunneling/README.md
+++ b/modules/iap-tunneling/README.md
@@ -87,6 +87,7 @@ the necessary APIs enabled.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | `list(string)` | `[]` | no |
+| create\_firewall\_rule | If we need to create the firewall rule or not. | `bool` | `true` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP. | `string` | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID. | `string` | `""` | no |
 | instances | Names and zones of the instances to allow SSH from IAP. | <pre>list(object({<br>    name = string<br>    zone = string<br>  }))</pre> | n/a | yes |

--- a/modules/iap-tunneling/main.tf
+++ b/modules/iap-tunneling/main.tf
@@ -15,6 +15,7 @@
  */
 
 resource "google_compute_firewall" "allow_from_iap_to_instances" {
+  count   = var.create_firewall_rule ? 1 : 0
   project = var.host_project != "" ? var.host_project : var.project
   name    = var.fw_name_allow_ssh_from_iap
   network = var.network

--- a/modules/iap-tunneling/variables.tf
+++ b/modules/iap-tunneling/variables.tf
@@ -62,3 +62,9 @@ variable "additional_ports" {
   type        = list(string)
   default     = []
 }
+
+variable "create_firewall_rule" {
+  type        = bool
+  description = "If we need to create the firewall rule or not."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,9 @@ variable "access_config" {
     public_ptr_domain_name = ""
   }]
 }
+
+variable "create_firewall_rule" {
+  type        = bool
+  description = "If we need to create the firewall rule or not."
+  default     = true
+}


### PR DESCRIPTION
In some cases, you might not have permission to create firewall rules on the host projects
(like hub and spoke architecture).