### PR TITLE
feat: update TPG version constraints to allow 4.0

### DIFF
--- a/examples/bastion_group/versions.tf
+++ b/examples/bastion_group/versions.tf
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 terraform {
-  required_version = ">=0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "~> 4.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
+      version = "~> 4.0"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bastion_group/versions.tf
+++ b/examples/bastion_group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 4.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = "~> 4.0"
     }
     random = {

--- a/examples/iap_tunneling/main.tf
+++ b/examples/iap_tunneling/main.tf
@@ -40,7 +40,7 @@ module "instance_template" {
   source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
 
   #source  = "terraform-google-modules/vm/google//modules/instance_template"
-  #version = "1.1.0"
+  #version = "~> 7.3"
 
   project_id   = var.project
   machine_type = "n1-standard-1"

--- a/examples/iap_tunneling/main.tf
+++ b/examples/iap_tunneling/main.tf
@@ -37,8 +37,10 @@ resource "google_service_account" "vm_sa" {
 
 # A testing VM to allow OS Login + IAP tunneling.
 module "instance_template" {
-  source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "1.1.0"
+  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
+
+  #source  = "terraform-google-modules/vm/google//modules/instance_template"
+  #version = "1.1.0"
 
   project_id   = var.project
   machine_type = "n1-standard-1"

--- a/examples/iap_tunneling/main.tf
+++ b/examples/iap_tunneling/main.tf
@@ -37,10 +37,8 @@ resource "google_service_account" "vm_sa" {
 
 # A testing VM to allow OS Login + IAP tunneling.
 module "instance_template" {
-  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
-
-  #source  = "terraform-google-modules/vm/google//modules/instance_template"
-  #version = "~> 7.3"
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 7.3"
 
   project_id   = var.project
   machine_type = "n1-standard-1"

--- a/examples/iap_tunneling/versions.tf
+++ b/examples/iap_tunneling/versions.tf
@@ -17,7 +17,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 4.0"
     }
   }

--- a/examples/iap_tunneling/versions.tf
+++ b/examples/iap_tunneling/versions.tf
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 terraform {
-  required_version = ">=0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "~> 4.0"
     }
   }
 }

--- a/examples/simple_example/versions.tf
+++ b/examples/simple_example/versions.tf
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 terraform {
-  required_version = ">=0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "~> 4.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
+      version = "~> 4.0"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/simple_example/versions.tf
+++ b/examples/simple_example/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 4.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = "~> 4.0"
     }
     random = {

--- a/examples/two_service_example/versions.tf
+++ b/examples/two_service_example/versions.tf
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 terraform {
-  required_version = ">=0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = "~> 4.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
+      version = "~> 4.0"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/two_service_example/versions.tf
+++ b/examples/two_service_example/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "~> 4.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = "~> 4.0"
     }
     random = {

--- a/main.tf
+++ b/main.tf
@@ -43,10 +43,8 @@ resource "google_service_account" "bastion_host" {
 }
 
 module "instance_template" {
-  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
-
-  #source  = "terraform-google-modules/vm/google//modules/instance_template"
-  #version = "~> 7.3"
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 7.3"
 
   name_prefix        = var.name_prefix
   project_id         = var.project

--- a/main.tf
+++ b/main.tf
@@ -43,8 +43,10 @@ resource "google_service_account" "bastion_host" {
 }
 
 module "instance_template" {
-  source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "~> 6.0"
+  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
+
+  #source  = "terraform-google-modules/vm/google//modules/instance_template"
+  #version = "~> 6.0"
 
   name_prefix        = var.name_prefix
   project_id         = var.project

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ module "instance_template" {
   source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/instance_template?ref=master"
 
   #source  = "terraform-google-modules/vm/google//modules/instance_template"
-  #version = "~> 6.0"
+  #version = "~> 7.3"
 
   name_prefix        = var.name_prefix
   project_id         = var.project

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -40,8 +40,10 @@ module "iap_bastion" {
 }
 
 module "mig" {
-  source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "~> 6.0"
+  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/mig?ref=master"
+
+  #source  = "terraform-google-modules/vm/google//modules/mig"
+  #version = "~> 6.0"
 
   project_id        = var.project
   region            = var.region

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -43,7 +43,7 @@ module "mig" {
   source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/mig?ref=master"
 
   #source  = "terraform-google-modules/vm/google//modules/mig"
-  #version = "~> 6.0"
+  #version = "~> 7.3"
 
   project_id        = var.project
   region            = var.region

--- a/modules/bastion-group/main.tf
+++ b/modules/bastion-group/main.tf
@@ -40,10 +40,8 @@ module "iap_bastion" {
 }
 
 module "mig" {
-  source = "github.com/terraform-google-modules/terraform-google-vm.git//modules/mig?ref=master"
-
-  #source  = "terraform-google-modules/vm/google//modules/mig"
-  #version = "~> 7.3"
+  source  = "terraform-google-modules/vm/google//modules/mig"
+  version = "~> 7.3"
 
   project_id        = var.project
   region            = var.region

--- a/modules/bastion-group/versions.tf
+++ b/modules/bastion-group/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_version = ">=0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = ">= 3.53, < 5.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = ">= 3.53, < 5.0"
     }
     random = {

--- a/modules/bastion-group/versions.tf
+++ b/modules/bastion-group/versions.tf
@@ -18,9 +18,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = ">= 3.53, < 5.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
+      version = ">= 3.53, < 5.0"
     }
     random = {
       source = "hashicorp/random"

--- a/modules/iap-tunneling/versions.tf
+++ b/modules/iap-tunneling/versions.tf
@@ -18,6 +18,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = ">= 3.53, < 5.0"
     }
   }
   provider_meta "google" {

--- a/modules/iap-tunneling/versions.tf
+++ b/modules/iap-tunneling/versions.tf
@@ -17,7 +17,7 @@ terraform {
   required_version = ">=0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = ">= 3.53, < 5.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_version = ">=0.13"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = ">= 3.53, < 5.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
       version = ">= 3.53, < 5.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -21,8 +21,7 @@ terraform {
       version = ">= 3.53, < 5.0"
     }
     random = {
-      source  = "hashicorp/random"
-      version = ">= 3.53, < 5.0"
+      source = "hashicorp/random"
     }
   }
   provider_meta "google" {

--- a/versions.tf
+++ b/versions.tf
@@ -18,9 +18,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
+      version = ">= 3.53, < 5.0"
     }
     random = {
       source = "hashicorp/random"
+      version = ">= 3.53, < 5.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
This has now been updated to use the latest released version of the `vm` module and is (pending review obviously!) ready to merge.