### PR TITLE
Renamed the ephemeral_ip variable to external_ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-* Renamed the `ephemeral_ip` variable to `external_ip` as it is possible to specify not only an ephemeral IP but also a static external IP.
-
 ## [4.1.0](https://www.github.com/terraform-google-modules/terraform-google-bastion-host/compare/v4.0.0...v4.1.0) (2021-11-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Renamed the `ephemeral_ip` variable to `external_ip` as it is possible to specify not only an ephemeral IP but also a static external IP.
+
 ## [4.1.0](https://www.github.com/terraform-google-modules/terraform-google-bastion-host/compare/v4.0.0...v4.1.0) (2021-11-25)
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If the user does not share the same domain as the org the bastion is in, you wil
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | `bool` | `true` | no |
 | disk\_size\_gb | Boot disk size in GB | `number` | `100` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
-| ephemeral\_ip | Set to true if an ephemeral external IP/DNS is required, must also set access\_config if true | `bool` | `false` | no |
+| external\_ip | Set to true if an ephemeral or static external IP/DNS is required, must also set access\_config if true | `bool` | `false` | no |
 | fw\_name\_allow\_ssh\_from\_iap | Firewall rule name for allowing SSH from IAP | `string` | `"allow-ssh-from-iap-to-tunnel"` | no |
 | host\_project | The network host project ID | `string` | `""` | no |
 | image | Source image for the Bastion. If image is not specified, image\_family will be used (which is the default). | `string` | `""` | no |

--- a/docs/upgrading_to_v5.0.md
+++ b/docs/upgrading_to_v5.0.md
@@ -1,0 +1,24 @@
+# Upgrading to terraform-google-bastion-host v5.x
+
+The v5.0 release of Google Bastion Host is a backwards incompatible release. 
+Below a list of the breaking changes and the migration instructions.
+
+## ⚠ BREAKING CHANGES
+
+* Renamed the `ephemeral_ip` variable to `external_ip` as it is possible to specify not only an ephemeral IP but also a static external IP.
+
+## Migration Instructions
+
+The following diff shows the breaking changes introduced in version 5 compared to version 4.
+
+```diff
+module "iap_bastion" {
+  source   = "terraform-google-modules/bastion-host/google"
+- version  = "v4.1"
++ version  = "v5.0"
+
+- ephemeral_ip = true
++ external_ip = true
+
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "google_compute_instance_from_template" "bastion_vm" {
   network_interface {
     subnetwork         = var.subnet
     subnetwork_project = var.host_project != "" ? var.host_project : var.project
-    access_config      = var.ephemeral_ip ? var.access_config : []
+    access_config      = var.external_ip ? var.access_config : []
   }
 
   source_instance_template = module.instance_template.self_link

--- a/modules/bastion-group/versions.tf
+++ b/modules/bastion-group/versions.tf
@@ -29,9 +29,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-bastion-host:bastion-group/v4.1.0"
-  }
-  provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-bastion-host:bastion-group/v4.1.0"
+    module_name = "blueprints/terraform/terraform-google-bastion-host:bastion-group/v5.0.0"
   }
 }

--- a/modules/iap-tunneling/versions.tf
+++ b/modules/iap-tunneling/versions.tf
@@ -22,6 +22,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-bastion-host:iap-tunneling/v4.1.0"
+    module_name = "blueprints/terraform/terraform-google-bastion-host:iap-tunneling/v5.0.0"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -204,9 +204,9 @@ variable "metadata" {
   default     = {}
 }
 
-variable "ephemeral_ip" {
+variable "external_ip" {
   type        = bool
-  description = "Set to true if an ephemeral external IP/DNS is required, must also set access_config if true"
+  description = "Set to true if an ephemeral or static external IP/DNS is required, must also set access_config if true"
   default     = false
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -25,6 +25,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-bastion-host/v4.1.0"
+    module_name = "blueprints/terraform/terraform-google-bastion-host/v5.0.0"
   }
 }


### PR DESCRIPTION
I think it is a good idea to rename the ephemeral_ip variable to external_ip as it is possible to specify not only an ephemeral IP but also a static IP. Since this is a breaking change it might be part of release 5.