### PR TITLE
apply labels to bastion instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,7 @@ resource "google_compute_instance_from_template" "bastion_vm" {
   name    = var.name
   project = var.project
   zone    = var.zone
+  labels  = var.labels
 
   network_interface {
     subnetwork         = var.subnet


### PR DESCRIPTION
This change applies labels to `google_compute_instance_from_template`.