### PR TITLE
add can_ip_forward variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If the user does not share the same domain as the org the bastion is in, you wil
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configs for network, nat\_ip and DNS | <pre>list(object({<br>    network_tier           = string<br>    nat_ip                 = string<br>    public_ptr_domain_name = string<br>  }))</pre> | <pre>[<br>  {<br>    "nat_ip": "",<br>    "network_tier": "PREMIUM",<br>    "public_ptr_domain_name": ""<br>  }<br>]</pre> | no |
 | additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | `list(string)` | `[]` | no |
+| can\_ip\_forward | If we need to enable ip forwarding | `bool` | `false` | no |
 | create\_firewall\_rule | If we need to create the firewall rule or not. | `bool` | `true` | no |
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | `bool` | `true` | no |
 | disk\_size\_gb | Boot disk size in GB | `number` | `100` | no |

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ module "instance_template" {
   startup_script       = var.startup_script
   preemptible          = var.preemptible
   can_ip_forward       = var.can_ip_forward
+  access_config        = var.access_config
 
   tags   = var.tags
   labels = var.labels
@@ -86,6 +87,7 @@ resource "google_compute_instance_from_template" "bastion_vm" {
     subnetwork         = var.subnet
     subnetwork_project = var.host_project != "" ? var.host_project : var.project
     access_config      = var.external_ip ? var.access_config : []
+#    access_config      = var.external_ip != "" ? var.access_config : [{nat_ip : var.external_ip, network_tier : "PREMIUM", public_ptr_domain_name : ""}]
   }
 
   source_instance_template = module.instance_template.self_link

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ module "instance_template" {
   source_image_project = var.image_project
   startup_script       = var.startup_script
   preemptible          = var.preemptible
+  can_ip_forward       = var.can_ip_forward
 
   tags   = var.tags
   labels = var.labels

--- a/variables.tf
+++ b/variables.tf
@@ -235,3 +235,9 @@ variable "create_firewall_rule" {
   description = "If we need to create the firewall rule or not."
   default     = true
 }
+
+variable "can_ip_forward" {
+  type        = bool
+  description = "If we need to enable ip forwarding"
+  default     = false
+}


### PR DESCRIPTION
This would allow setting `can_ip_forward` to be accessible in this bastion module instance template.