### PR TITLE
feat: add disk_labels to bastion host instance_template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ module "instance_template" {
   machine_type        = var.machine_type
   disk_size_gb        = var.disk_size_gb
   disk_type           = var.disk_type
+  disk_labels         = var.disk_labels
   subnetwork          = var.subnet
   subnetwork_project  = var.host_project
   additional_networks = var.additional_networks

--- a/variables.tf
+++ b/variables.tf
@@ -198,6 +198,13 @@ variable "disk_type" {
   default     = "pd-standard"
 }
 
+variable "disk_labels" {
+  type = map(any)
+
+  description = "Key-value map of labels to assign to the bastion host disk"
+  default     = {}
+}
+
 variable "metadata" {
   type        = map(string)
   description = "Key-value map of additional metadata to assign to the instances"


### PR DESCRIPTION
This PR adds the capability to configure the bastion host's disk labels.