### PR TITLE
feat: allow bastion host to be created with KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If the user does not share the same domain as the org the bastion is in, you wil
 | additional\_ports | A list of additional ports/ranges to open access to on the instances from IAP. | `list(string)` | `[]` | no |
 | create\_firewall\_rule | If we need to create the firewall rule or not. | `bool` | `true` | no |
 | create\_instance\_from\_template | Whether to create and instance from the template or not. If false, no instance is created, but the instance template is created and usable by a MIG | `bool` | `true` | no |
+| disk\_encryption\_key | The key used to encrypt the bastion host disk. If not set, the disk will not be encrypted. | `string` | `null` | no |
 | disk\_labels | Key-value map of labels to assign to the bastion host disk | `map(any)` | `{}` | no |
 | disk\_size\_gb | Boot disk size in GB | `number` | `100` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |

--- a/examples/two_service_example/README.md
+++ b/examples/two_service_example/README.md
@@ -83,6 +83,6 @@ You can also try SSHing to the other host, priv-host-a-2. This should work. Try 
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ module "instance_template" {
   subnetwork_project  = var.host_project
   additional_networks = var.additional_networks
   region              = var.region
+  disk_encryption_key = var.disk_encryption_key
 
   service_account = {
     email  = local.service_account_email

--- a/modules/iap-tunneling/README.md
+++ b/modules/iap-tunneling/README.md
@@ -99,7 +99,7 @@ the necessary APIs enabled.
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,13 @@ variable "region" {
   default     = null
 }
 
+variable "disk_encryption_key" {
+  type = string
+
+  description = "The key used to encrypt the bastion host disk. If not set, the disk will not be encrypted."
+  default     = null
+}
+
 variable "random_role_id" {
   type = bool
 


### PR DESCRIPTION
This PR adds the variable `disk_encryption_key` to allow the instance template to be configured with a cloud KMS key. This is useful in cases where e.g. [an organization policy](https://cloud.google.com/storage/docs/org-policy-constraints#restrict-noncmek-services) says that all disks created must be encrypted with CMEK keys.