### PR TITLE
Prevent unnecessary "bastion_vm" replacement when upgrading to 9.x version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,8 +104,11 @@ resource "google_compute_instance_from_template" "bastion_vm" {
 
   source_instance_template = module.instance_template.self_link
 
-  params {
-    resource_manager_tags = var.resource_manager_tags
+  dynamic "params" {
+    for_each = var.resource_manager_tags == null ? [] : [1]
+    content {
+      resource_manager_tags = var.resource_manager_tags
+    }
   }
 }
 


### PR DESCRIPTION
### Description

This PR fixes an issue in version `9.0.0` where adding `params` block to an existing bastion host instance would force unnecessary VM replacement.

### Problem

In the current implementation, the `params` block is always present in the `google_compute_instance_from_template.bastion_vm` resource, which causes Terraform to force replacement of the VM when resource_manager_tags are added to an existing instance:

```hcl
# module.iap_bastion_host.google_compute_instance_from_template.bastion_vm[0] must be replaced
-/+ resource "google_compute_instance_from_template" "bastion_vm" {
  ...
+ params { # forces replacement
    + resource_manager_tags = (known after apply)
  }
  ...
}
```

### Solution

The fix implements a dynamic "params" block that only creates the params configuration when var.resource_manager_tags is not null. This prevents unnecessary VM destruction and recreation when resource manager tags are added or modified.
